### PR TITLE
Fix LinkedIn config link

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -71,9 +71,9 @@ export const Navbar = () => {
 
 			<NavbarContent className="hidden sm:flex basis-1/5 sm:basis-full" justify="end">
 				<NavbarItem className="hidden sm:flex gap-2">
-					<Link isExternal href={siteConfig.links.linkeding}>
-						<LinkedingLogo className="text-default-500" />
-					</Link>
+                                       <Link isExternal href={siteConfig.links.linkedin}>
+                                               <LinkedingLogo className="text-default-500" />
+                                       </Link>
 					<Link isExternal href={siteConfig.links.github}>
 						<GithubIcon className="text-default-500" />
 					</Link>
@@ -82,9 +82,9 @@ export const Navbar = () => {
 			</NavbarContent>
 
 			<NavbarContent className="sm:hidden basis-1 pl-4 text-white" justify="end">
-				<Link isExternal href={siteConfig.links.linkeding}>
-						<LinkedingLogo className="text-default-500" />
-				</Link>
+                                <Link isExternal href={siteConfig.links.linkedin}>
+                                                <LinkedingLogo className="text-default-500" />
+                                </Link>
 				<Link isExternal href={siteConfig.links.github}>
 					<GithubIcon className="text-default-500" />
 				</Link>

--- a/config/site.ts
+++ b/config/site.ts
@@ -42,7 +42,7 @@ export const siteConfig = {
 		}
 	],
 	links: {
-		github: "https://github.com/Mauro-js",
-		linkeding: "https://www.linkedin.com/in/mauro-nievas-11b0bb11b/",
-	},
+               github: "https://github.com/Mauro-js",
+               linkedin: "https://www.linkedin.com/in/mauro-nievas-11b0bb11b/",
+       },
 };


### PR DESCRIPTION
## Summary
- rename `linkeding` property to `linkedin` in `siteConfig`
- update navbar to use `siteConfig.links.linkedin`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687135d34908833287caa583394f4777